### PR TITLE
retrained yolo5 large and updated s3 bucket location

### DIFF
--- a/deeplite_torch_zoo/wrappers/models/objectdetection/yolo5.py
+++ b/deeplite_torch_zoo/wrappers/models/objectdetection/yolo5.py
@@ -21,10 +21,9 @@ __all__ = [
 ]
 
 model_urls = {
-
     "yolov5s_voc_20": "http://download.deeplite.ai/zoo/models/yolo5s-voc-20classes_817-0325eb3aa0a02a50.pt",
     "yolov5m_voc_20": "http://download.deeplite.ai/zoo/models/yolo5m-voc-20classes_882-c2ad7d49ecfb27b3.pt",
-    "yolov5l_voc_20": "http://download.deeplite.ai/zoo/models/yolo5l-voc-20classes_900-1cd7a96dd9d645db.pt",
+    "yolov5l_voc_20": "http://download.deeplite.ai/zoo/models/yolo5l-voc-20classes_899-411aefb761eafaa3.pt",
     "yolov5x_voc_20": "http://download.deeplite.ai/zoo/models/yolo5x-voc-20classes_905-e8ddd018ae29751f.pt",
     "yolov5s_coco_80": "deeplite_torch_zoo/weight/yolo5s-coco-80classes.pt",
     "yolov5m_coco_80": "deeplite_torch_zoo/weight/yolo5m-coco-80classes.pt",


### PR DESCRIPTION
Retrained yolo5 large on voc 20, reached 0.899 mAP. Uploaded model into s3 and updating the s3 location for yolov5l_voc_20.