### PR TITLE
fix coco eval bug

### DIFF
--- a/deeplite_torch_zoo/src/objectdetection/eval/coco/coco_evaluator.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/coco/coco_evaluator.py
@@ -22,7 +22,6 @@ class COCOEvaluator(Evaluator):
         gt=None,
         progressbar=False,
     ):
-        # data_path = "results/coco/{net}/".format(net=net)
         super(COCOEvaluator, self).__init__(
             model=model, img_size=img_size
         )

--- a/deeplite_torch_zoo/src/objectdetection/eval/coco/coco_evaluator.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/coco/coco_evaluator.py
@@ -22,9 +22,9 @@ class COCOEvaluator(Evaluator):
         gt=None,
         progressbar=False,
     ):
-        data_path = "results/coco/{net}/".format(net=net)
+        # data_path = "results/coco/{net}/".format(net=net)
         super(COCOEvaluator, self).__init__(
-            model=model, data_path=data_path, net=net, img_size=img_size
+            model=model, net=net, img_size=img_size
         )
         self.dataset = dataset
         self.progressbar = progressbar

--- a/deeplite_torch_zoo/src/objectdetection/eval/coco/coco_evaluator.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/coco/coco_evaluator.py
@@ -24,7 +24,7 @@ class COCOEvaluator(Evaluator):
     ):
         # data_path = "results/coco/{net}/".format(net=net)
         super(COCOEvaluator, self).__init__(
-            model=model, net=net, img_size=img_size
+            model=model, img_size=img_size
         )
         self.dataset = dataset
         self.progressbar = progressbar

--- a/deeplite_torch_zoo/src/objectdetection/eval/lisa_eval.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/lisa_eval.py
@@ -39,9 +39,9 @@ class Demo(Evaluator):
         net="yolov3",
         img_size=448,
     ):
-        data_path = "deeplite_torch_zoo/results/lisa/{net}".format(net=net)
+        # data_path = "deeplite_torch_zoo/results/lisa/{net}".format(net=net)
         super(Demo, self).__init__(
-            model=model, data_path=data_path, img_size=img_size, net=net
+            model=model, img_size=img_size, net=net
         )
 
         self.data_root = data_root

--- a/deeplite_torch_zoo/src/objectdetection/eval/lisa_eval.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/lisa_eval.py
@@ -39,7 +39,6 @@ class Demo(Evaluator):
         net="yolov3",
         img_size=448,
     ):
-        # data_path = "deeplite_torch_zoo/results/lisa/{net}".format(net=net)
         super(Demo, self).__init__(
             model=model, img_size=img_size)
 
@@ -82,9 +81,8 @@ class LISAEval(Evaluator):
     """docstring for LISAEval"""
 
     def __init__(self, model, data_root, visiual=False, net="yolov3", img_size=448):
-        data_path = "deeplite_torch_zoo/results/lisa/{net}".format(net=net)
         super(LISAEval, self).__init__(
-            model=model, data_path=data_path, img_size=img_size, net=net
+            model=model, img_size=img_size, net=net
         )
 
         self.dataset = val_dataset = LISA(data_root, _set="valid")

--- a/deeplite_torch_zoo/src/objectdetection/eval/lisa_eval.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/lisa_eval.py
@@ -41,8 +41,7 @@ class Demo(Evaluator):
     ):
         # data_path = "deeplite_torch_zoo/results/lisa/{net}".format(net=net)
         super(Demo, self).__init__(
-            model=model, img_size=img_size, net=net
-        )
+            model=model, img_size=img_size)
 
         self.data_root = data_root
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/deeplite_torch_zoo/src/objectdetection/eval/wider_face_eval.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/wider_face_eval.py
@@ -30,9 +30,9 @@ class WiderFaceEval(Evaluator):
     """docstring for WiderFaceEval"""
 
     def __init__(self, model, data_root, net="yolov3", img_size=448):
-        data_path = "deeplite_torch_zoo/results/wider_face/{net}".format(net=net)
+        # data_path = "deeplite_torch_zoo/results/wider_face/{net}".format(net=net)
         super(WiderFaceEval, self).__init__(
-            model=model, data_path=data_path, img_size=img_size, net=net
+            model=model, img_size=img_size, net=net
         )
 
         self.dataset = WiderFace(data_root, split="val")

--- a/deeplite_torch_zoo/src/objectdetection/eval/wider_face_eval.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/wider_face_eval.py
@@ -32,8 +32,7 @@ class WiderFaceEval(Evaluator):
     def __init__(self, model, data_root, net="yolov3", img_size=448):
         # data_path = "deeplite_torch_zoo/results/wider_face/{net}".format(net=net)
         super(WiderFaceEval, self).__init__(
-            model=model, img_size=img_size, net=net
-        )
+            model=model, img_size=img_size)
 
         self.dataset = WiderFace(data_root, split="val")
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/deeplite_torch_zoo/src/objectdetection/eval/wider_face_eval.py
+++ b/deeplite_torch_zoo/src/objectdetection/eval/wider_face_eval.py
@@ -30,7 +30,6 @@ class WiderFaceEval(Evaluator):
     """docstring for WiderFaceEval"""
 
     def __init__(self, model, data_root, net="yolov3", img_size=448):
-        # data_path = "deeplite_torch_zoo/results/wider_face/{net}".format(net=net)
         super(WiderFaceEval, self).__init__(
             model=model, img_size=img_size)
 

--- a/deeplite_torch_zoo/wrappers/datasets/objectdetection/ssd.py
+++ b/deeplite_torch_zoo/wrappers/datasets/objectdetection/ssd.py
@@ -111,6 +111,7 @@ for dataset_name_key, wrapper_fn in DATASET_WRAPPER_FNS.items():
 
 VOC_DATASET_MODEL_WRAPPERS = {
     'mb1_ssd': MOBILENET_CONFIG(),
+    'mb2_ssd': MOBILENET_CONFIG(),
     'mb2_ssd_lite': MOBILENET_CONFIG(),
     'resnet18_ssd': VGG_CONFIG(),
     'resnet34_ssd': VGG_CONFIG(),


### PR DESCRIPTION
Problem: running coco2017 eval crashes

Solution: remove unsupported data_path arg from OD evaluator call in coco, widerface, lisa evaluators


example: `python src/hello_neutrino_yolo_coco.py -a yolo5_6n -b 8 `  causes error below
```
TypeError: __init__() got an unexpected keyword argument 'data_path'
```
at 
https://github.com/Deeplite/deeplite-torch-zoo/blob/815578841dbc1c6bc3099f2156cdd7f2fba70748/deeplite_torch_zoo/src/objectdetection/eval/coco/coco_evaluator.py#L26-L28

Second problem: mb2_ssd has a trained model path but was inaccessible via wrappers, so added it back